### PR TITLE
Fix logger lookup to correctly check for non-nil context key

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -76,7 +76,7 @@ func (x *Logger) Log(ctx context.Context, severity tracelog.LogLevel, message st
 }
 
 func (x *Logger) logger(ctx context.Context) *slog.Logger {
-	if key := x.ContextKey; key == nil {
+	if key := x.ContextKey; key != nil {
 		if logger, ok := ctx.Value(key).(*slog.Logger); ok {
 			return logger
 		}


### PR DESCRIPTION
This PR fixes a logic bug in the logger method of pgxslog.Logger where the contextual logger was never retrieved because the key check was reversed.

Before: it only attempted to fetch from context if the key was nil.
Now: it properly attempts lookup only if ContextKey != nil.

This ensures pgx logging works correctly when a context-aware logger is injected.